### PR TITLE
[Ubuntu24.04] Fix llvm-project in vpux_plugin fails to compile because of uninitialized variable

### DIFF
--- a/llvm/include/llvm/Support/FormatProviders.h
+++ b/llvm/include/llvm/Support/FormatProviders.h
@@ -130,7 +130,7 @@ struct format_provider<
 private:
 public:
   static void format(const T &V, llvm::raw_ostream &Stream, StringRef Style) {
-    HexPrintStyle HS;
+    HexPrintStyle HS = HexPrintStyle::PrefixUpper;
     size_t Digits = 0;
     if (consumeHexStyle(Style, HS)) {
       Digits = consumeNumHexDigits(Style, HS, 0);


### PR DESCRIPTION
## Summary
Error:
```
llvm-project/llvm/include/llvm/Support/FormatProviders.h:133:19: note: 'HS' was declared here
  133 |     HexPrintStyle HS;
```

## JIRA ticket

* E-127832

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* PR-xxx

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
