### PR TITLE
Fix <anonymous> declared here

### DIFF
--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -151,7 +151,7 @@ protected:
       void *StoragePtr;
       size_t Size;
       size_t Alignment;
-    } OutOfLineStorage;
+    } OutOfLineStorage = {};
     static_assert(
         sizeof(OutOfLineStorageT) <= InlineStorageSize,
         "Should always use all of the out-of-line storage for inline storage!");


### PR DESCRIPTION
## Summary
[Ubuntu24.04] llvm-project in vpux_plugin fails to compile due to:
```
/build/third_party/vpux_plugin/src/vpux_plugin/src/vpux_compiler/src/dialect/const/utils/constant_folding_cache.cpp:26:22:
/usr/include/c++/13/bits/atomic_base.h:481:25: error: 'void __atomic_store_8(volatile void*, long unsigned int, int)' writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
  481 |         __atomic_store_n(&_M_i, __i, int(__m));
      |         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In member function 'vpux::Const::FoldingRequest vpux::Const::ConstantFoldingCache::getRequest()':
cc1plus: note: destination object is likely at address zero
```

```
error: redundant move in initialization [-Werror=redundant-move]
      update_concat_out_fq(std::move(node), fqs_to_align);
```

```
vpux_plugin/thirdparty/llvm-project/llvm/include/llvm/ADT/FunctionExtras.h:307:7: error: '<unnamed>.llvm::unique_function<__attribute__((const)) bool(mlir::OpOperand&)>::<unnamed>.llvm::detail::UniqueFunctionBase<bool, mlir::OpOperand&>::StorageUnion.llvm::detail::UniqueFunctionBase<bool, mlir::OpOperand&>::StorageUnionT::OutOfLineStorage' may be used uninitialized [-Werror=maybe-uninitialized]
      StorageUnion.OutOfLineStorage = RHS.StorageUnion.OutOfLineStorage;
```

```
c++/13/bits/stl_algobase.h:437:30: error: 'void* __builtin_memmove(void*, const void*, long unsigned int)' forming offset 200 is out of the bounds [0, 200] of object '<anonymous>' with type 'llvm::SmallVector<VPUNN::DPULayer>' [-Werror=array-bounds=]
       __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
```

etc

## JIRA ticket

* E-127832

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* PR-xxx

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
