### PR TITLE
Add support to PrintIRPass for printing flags and target dump file

### DIFF
--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -69,7 +69,7 @@ std::unique_ptr<Pass> createControlFlowSinkPass();
 std::unique_ptr<Pass> createCSEPass();
 
 /// Creates a pass to print IR on the debug stream.
-std::unique_ptr<Pass> createPrintIRPass(const PrintIRPassOptions & = {});
+std::unique_ptr<Pass> createPrintIRPass(const PrintIRPassOptions & = {}, OpPrintingFlags printingFlags = std::nullopt);
 
 /// Creates a pass that generates IR to verify ops at runtime.
 std::unique_ptr<Pass> createGenerateRuntimeVerificationPass();

--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -251,6 +251,7 @@ def PrintIRPass : Pass<"print-ir"> {
   let constructor = "mlir::createPrintIRPass()";
   let options = [
     Option<"label", "label", "std::string", /*default=*/"", "Label">,
+    Option<"file", "file", "std::string", /*default=*/"", "File">,
   ];
 }
 

--- a/mlir/lib/Transforms/PrintIR.cpp
+++ b/mlir/lib/Transforms/PrintIR.cpp
@@ -25,7 +25,7 @@ struct PrintIRPass : public impl::PrintIRPassBase<PrintIRPass> {
 
   void runOnOperation() override {
     if (this->file.empty()) {
-      printIRTo(llvm::errs());
+      printIR(llvm::errs());
       return;
     }
 
@@ -38,11 +38,11 @@ struct PrintIRPass : public impl::PrintIRPassBase<PrintIRPass> {
       return;
     }
 
-    printIRTo(stream);
+    printIR(stream);
   }
 
 private:
-  void printIRTo(llvm::raw_ostream &stream) {
+  void printIR(llvm::raw_ostream &stream) {
     stream << "// -----// IR Dump";
     if (!this->label.empty())
       stream << " " << this->label;

--- a/mlir/lib/Transforms/PrintIR.cpp
+++ b/mlir/lib/Transforms/PrintIR.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/FileSystem.h"
 
 namespace mlir {
 namespace {
@@ -17,21 +18,47 @@ namespace {
 #include "mlir/Transforms/Passes.h.inc"
 
 struct PrintIRPass : public impl::PrintIRPassBase<PrintIRPass> {
-  using impl::PrintIRPassBase<PrintIRPass>::PrintIRPassBase;
+  PrintIRPass(const PrintIRPassOptions &options):
+    PrintIRPassBase(options) {}
+
+  PrintIRPass(const PrintIRPassOptions &options, OpPrintingFlags printingFlags):
+    PrintIRPassBase(options), printingFlags(printingFlags) {}
 
   void runOnOperation() override {
-    llvm::dbgs() << "// -----// IR Dump";
-    if (!this->label.empty())
-      llvm::dbgs() << " " << this->label;
-    llvm::dbgs() << " //----- //\n";
-    getOperation()->dump();
+    if (this->file.empty()) {
+      printIRTo(llvm::errs());
+      return;
+    }
+
+    std::error_code EC;
+    llvm::raw_fd_ostream stream(this->file, EC, llvm::sys::fs::OF_Append);
+
+    if (EC) {
+      llvm::errs() << "Could not open file: " << EC.message();
+      signalPassFailure();
+      return;
+    }
+
+    printIRTo(stream);
   }
+
+private:
+  void printIRTo(llvm::raw_ostream &stream) {
+    stream << "// -----// IR Dump";
+    if (!this->label.empty())
+      stream << " " << this->label;
+    stream << " //----- //\n";
+
+    getOperation()->print(stream, printingFlags);
+  }
+
+  OpPrintingFlags printingFlags = std::nullopt;
 };
 
 } // namespace
 
-std::unique_ptr<Pass> createPrintIRPass(const PrintIRPassOptions &options) {
-  return std::make_unique<PrintIRPass>(options);
+std::unique_ptr<Pass> createPrintIRPass(const PrintIRPassOptions &options, OpPrintingFlags printingFlags) {
+  return std::make_unique<PrintIRPass>(options, printingFlags);
 }
 
 } // namespace mlir

--- a/mlir/lib/Transforms/PrintIR.cpp
+++ b/mlir/lib/Transforms/PrintIR.cpp
@@ -18,11 +18,10 @@ namespace {
 #include "mlir/Transforms/Passes.h.inc"
 
 struct PrintIRPass : public impl::PrintIRPassBase<PrintIRPass> {
-  PrintIRPass(const PrintIRPassOptions &options):
-    PrintIRPassBase(options) {}
+  PrintIRPass(const PrintIRPassOptions &options) : PrintIRPassBase(options) {}
 
-  PrintIRPass(const PrintIRPassOptions &options, OpPrintingFlags printingFlags):
-    PrintIRPassBase(options), printingFlags(printingFlags) {}
+  PrintIRPass(const PrintIRPassOptions &options, OpPrintingFlags printingFlags)
+      : PrintIRPassBase(options), printingFlags(printingFlags) {}
 
   void runOnOperation() override {
     if (this->file.empty()) {
@@ -57,7 +56,8 @@ private:
 
 } // namespace
 
-std::unique_ptr<Pass> createPrintIRPass(const PrintIRPassOptions &options, OpPrintingFlags printingFlags) {
+std::unique_ptr<Pass> createPrintIRPass(const PrintIRPassOptions &options,
+                                        OpPrintingFlags printingFlags) {
   return std::make_unique<PrintIRPass>(options, printingFlags);
 }
 


### PR DESCRIPTION
## Summary
Improves MLIR's PrintIRPass and makes it more fit for our use-case. It helps with debugging IR.

## JIRA ticket

[E-133691](https://jira.devtools.intel.com/browse/EISW-133691)

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

