### PR TITLE
Address binskim flag for compiler in driver build

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -765,6 +765,16 @@ if (MSVC)
 
   # Enable warnings
   if (LLVM_ENABLE_WARNINGS)
+    # Remove all -wd flag to enable warnings
+    if (NOT CLANG_CL)
+      set(msvc_warning_flags
+        # Promoted warnings.
+        -w14062 # Promote 'enumerator in switch of enum is not handled' to level 1 warning.
+
+        # Promoted warnings to errors.
+        -we4238 # Promote 'nonstandard extension used : class rvalue used as lvalue' to error.
+      )
+    endif(NOT CLANG_CL)
     # Put /W4 in front of all the -we flags. cl.exe doesn't care, but for
     # clang-cl having /W4 after the -we flags will re-enable the warnings
     # disabled by -we.


### PR DESCRIPTION
## Summary
> Since the compiler in the driver build cannot pass the Binskim scan and shows [Explicitly disabled warnings: 4146;4244;4267], it is necessary to remove the suppression of these three warnings. LLVM code like: 
> https://github.com/intel/npu-plugin-llvm/blob/dfee50054287ee9989f8ef64832ba08558ffd654/llvm/cmake/modules/HandleLLVMOptions.cmake#L692
> ``` cmake
>      -wd4146 # Suppress 'unary minus operator applied to unsigned type, result still unsigned'
>      -wd4244 # Suppress ''argument' : conversion from 'type1' to 'type2', possible loss of data'
>      -wd4267 # Suppress ''var' : conversion from 'size_t' to 'type', possible loss of data'
> ```
> -wd4146 means disable the /w4146 warning
> -wd4244 means disable the /w4244 warning
> -wd4267 means disable the /w4267 warning
>
> So we need enable these three warnings to pass the Binskim
>
> Since it is not possible to directly enable specific warnings for the LLVM repo within the compiler repo, we use an option here to control whether the specified warnings are suppressed.

## JIRA ticket

* [EISW-130780](https://jira.devtools.intel.com/browse/EISW-130780)

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* [PR-15919](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/15919)

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
