### PR TITLE
Add clang-tidy checker to use free functions for casting

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -40,6 +40,7 @@ add_clang_library(clangTidyMiscModule
   UnusedParametersCheck.cpp
   UnusedUsingDeclsCheck.cpp
   UseAnonymousNamespaceCheck.cpp
+  UseFreeFunctionVariantsCheck.cpp
 
   LINK_LIBS
   clangAnalysis

--- a/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
@@ -31,6 +31,7 @@
 #include "UnusedParametersCheck.h"
 #include "UnusedUsingDeclsCheck.h"
 #include "UseAnonymousNamespaceCheck.h"
+#include "UseFreeFunctionVariantsCheck.h"
 
 namespace clang::tidy {
 namespace misc {
@@ -78,6 +79,8 @@ public:
         "misc-unused-using-decls");
     CheckFactories.registerCheck<UseAnonymousNamespaceCheck>(
         "misc-use-anonymous-namespace");
+    CheckFactories.registerCheck<UseFreeFunctionVariantsCheck>(
+        "misc-use-free-function-variants");
   }
 };
 

--- a/clang-tools-extra/clang-tidy/misc/UseFreeFunctionVariantsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UseFreeFunctionVariantsCheck.cpp
@@ -1,0 +1,79 @@
+//===--- UseFreeFunctionVariantsCheck.cpp - clang-tidy --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "UseFreeFunctionVariantsCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Lex/Lexer.h"
+#include <iostream>
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::misc {
+
+void UseFreeFunctionVariantsCheck::registerMatchers(MatchFinder *Finder) {
+    Finder->addMatcher(cxxMemberCallExpr(on(expr().bind("base")),
+                                         callee(cxxMethodDecl(hasAnyName("isa", "dyn_cast", "cast")))
+                ).bind("castCall"),
+                       this);
+}
+
+// TODO(askrebko): Add checker for types wrapped in pointers and optional
+void UseFreeFunctionVariantsCheck::check(
+    const MatchFinder::MatchResult &Result) {
+    const auto* CallExpr = Result.Nodes.getNodeAs<CXXMemberCallExpr>("castCall");
+    const auto* BaseExpr = Result.Nodes.getNodeAs<Expr>("base");
+
+    if (!CallExpr || !BaseExpr) {
+        return;
+    }
+    SourceManager &SM = *Result.SourceManager;
+    LangOptions LangOpts = getLangOpts();
+
+    std::string BaseStr = Lexer::getSourceText(
+        CharSourceRange::getTokenRange(BaseExpr->getSourceRange()), SM, LangOpts).str();
+
+    const auto* MethodDecl = CallExpr->getMethodDecl();
+    if (!MethodDecl->getTemplateSpecializationArgs()) {
+        return;
+    }
+
+    std::string TemplateArgStr;
+    for (const auto& Arg : MethodDecl->getTemplateSpecializationArgs()->asArray()) {
+        if (Arg.getKind() == TemplateArgument::ArgKind::Type) {
+            PrintingPolicy Policy(LangOpts);
+            Policy.adjustForCPlusPlus();
+            if (!TemplateArgStr.empty()) {
+                TemplateArgStr += ", ";
+            }
+            TemplateArgStr += Arg.getAsType().getAsString(Policy);
+        } else if (Arg.getKind() == TemplateArgument::ArgKind::Pack) {
+            for (const auto& PackArg : Arg.pack_elements()) {
+                PrintingPolicy Policy(LangOpts);
+                Policy.adjustForCPlusPlus();
+                if (!TemplateArgStr.empty()) {
+                    TemplateArgStr += ", ";
+                }
+                TemplateArgStr += PackArg.getAsType().getAsString(Policy);
+            }
+        } else {
+            std::cout << "Unsupported template argument kind: " << Arg.getKind() << std::endl;
+            return;
+        }
+    }
+
+    std::string FuncName = MethodDecl->getNameAsString();
+
+    std::string Replacement = "mlir::" + FuncName + "<" + TemplateArgStr + ">(" + BaseStr + ")";
+    diag(CallExpr->getBeginLoc(), "Replace 'type.isa<T>()' with 'mlir::isa<T>(type)'")
+        << FixItHint::CreateReplacement(CallExpr->getSourceRange(), Replacement);
+}
+
+} // namespace clang::tidy::misc

--- a/clang-tools-extra/clang-tidy/misc/UseFreeFunctionVariantsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UseFreeFunctionVariantsCheck.cpp
@@ -20,7 +20,7 @@ namespace clang::tidy::misc {
 
 void UseFreeFunctionVariantsCheck::registerMatchers(MatchFinder *Finder) {
     Finder->addMatcher(cxxMemberCallExpr(on(expr().bind("base")),
-                                         callee(cxxMethodDecl(hasAnyName("isa", "dyn_cast", "cast")))
+                                         callee(cxxMethodDecl(hasAnyName("isa", "dyn_cast", "cast", "dyn_cast_or_null")))
                 ).bind("castCall"),
                        this);
 }

--- a/clang-tools-extra/clang-tidy/misc/UseFreeFunctionVariantsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UseFreeFunctionVariantsCheck.cpp
@@ -20,7 +20,7 @@ namespace clang::tidy::misc {
 
 void UseFreeFunctionVariantsCheck::registerMatchers(MatchFinder *Finder) {
     Finder->addMatcher(cxxMemberCallExpr(on(expr().bind("base")),
-                                         callee(cxxMethodDecl(hasAnyName("isa", "dyn_cast", "cast", "dyn_cast_or_null")))
+                                         callee(cxxMethodDecl(hasAnyName("isa", "dyn_cast", "cast", "dyn_cast_or_null", "isa_and_nonnull")))
                 ).bind("castCall"),
                        this);
 }

--- a/clang-tools-extra/clang-tidy/misc/UseFreeFunctionVariantsCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/UseFreeFunctionVariantsCheck.h
@@ -1,0 +1,30 @@
+//===--- UseFreeFunctionVariantsCheck.h - clang-tidy ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_USEFREEFUNCTIONVARIANTSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_USEFREEFUNCTIONVARIANTSCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang::tidy::misc {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/misc/use-free-function-variants.html
+class UseFreeFunctionVariantsCheck : public ClangTidyCheck {
+public:
+  UseFreeFunctionVariantsCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace clang::tidy::misc
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_USEFREEFUNCTIONVARIANTSCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -229,6 +229,11 @@ New checks
   points in a coroutine. Such hostile types include scoped-lockable types and
   types belonging to a configurable denylist.
 
+- New :doc:`misc-use-free-function-variants
+  <clang-tidy/checks/misc/use-free-function-variants>` check.
+
+  FIXME: add release notes.
+
 - New :doc:`modernize-use-constraints
   <clang-tidy/checks/modernize/use-constraints>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -265,6 +265,7 @@ Clang-Tidy Checks
    :doc:`misc-unused-parameters <misc/unused-parameters>`, "Yes"
    :doc:`misc-unused-using-decls <misc/unused-using-decls>`, "Yes"
    :doc:`misc-use-anonymous-namespace <misc/use-anonymous-namespace>`,
+   :doc:`misc-use-free-function-variants <misc/use-free-function-variants>`, "Yes"
    :doc:`modernize-avoid-bind <modernize/avoid-bind>`, "Yes"
    :doc:`modernize-avoid-c-arrays <modernize/avoid-c-arrays>`,
    :doc:`modernize-concat-nested-namespaces <modernize/concat-nested-namespaces>`, "Yes"

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/use-free-function-variants.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/use-free-function-variants.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - misc-use-free-function-variants
+
+misc-use-free-function-variants
+===============================
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-free-function-variants.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-free-function-variants.cpp
@@ -1,0 +1,14 @@
+// RUN: %check_clang_tidy %s misc-use-free-function-variants %t
+
+// FIXME: Add something that triggers the check here.
+void f();
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'f' is insufficiently awesome [misc-use-free-function-variants]
+
+// FIXME: Verify the applied fix.
+//   * Make the CHECK patterns specific enough and try to make verified lines
+//     unique to avoid incorrect matches.
+//   * Use {{}} for regular expressions.
+// CHECK-FIXES: {{^}}void awesome_f();{{$}}
+
+// FIXME: Add something that doesn't trigger the check here.
+void awesome_f2();


### PR DESCRIPTION
## Summary
> Please add a short but exhaustive summary why you think your pull request is useful

* Add a custom checker for automatic replacement of member variants of the dyn_cast/cast/isa with the corresponding free functions. For example,
```
if (type.isa<Foo>() && type.isa<Bar>()) { ... } 
// will be replaced by
if (mlir::isa<Foo>(type) && mlir::isa<Bar>(type)) { ... } 
```
More examples in https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/16360

## JIRA ticket

* [E-71627](https://jira.devtools.intel.com/browse/EISW-71627)

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* PR-xxx

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
