### PR TITLE
[EISW-164790] Minor fix to quant dialect's TypeParser

### DIFF
--- a/mlir/lib/Dialect/Quant/IR/TypeParser.cpp
+++ b/mlir/lib/Dialect/Quant/IR/TypeParser.cpp
@@ -51,7 +51,7 @@ static Type parseStorageType(DialectAsmParser &parser, bool &isSigned) {
         return nullptr;
       }
       isSigned = false;
-      type = parser.getBuilder().getIntegerType(storageTypeWidth);
+      type = parser.getBuilder().getIntegerType(storageTypeWidth, isSigned);
 
     } else {
       parser.emitError(typeLoc, "illegal quantized storage type alias");


### PR DESCRIPTION
## Summary
Passing signedness when creating unsigned integer for the storageType in type parser, to create an actual unsigned integer.

## JIRA ticket

* [E-164790](https://jira.devtools.intel.com/browse/EISW-164790)

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* [PR-17158](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/17158)

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
