### PR TITLE
EISW-163565 [Cleanup] Revert "Expose TimingManager OutputTextStrategy"

### DIFF
--- a/mlir/include/mlir/Support/Timing.h
+++ b/mlir/include/mlir/Support/Timing.h
@@ -17,7 +17,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMapEntry.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/Format.h"
 #include <optional>
 
 namespace mlir {
@@ -366,53 +365,6 @@ public:
   virtual void printTreeEntryEnd(unsigned indent, bool lastEntry = false) = 0;
 
   raw_ostream &os;
-};
-
-constexpr llvm::StringLiteral kTimingDescription =
-    "... Execution time report ...";
-
-class OutputTextStrategy : public OutputStrategy {
-public:
-  OutputTextStrategy(raw_ostream &os) : OutputStrategy(os) {}
-
-  void printHeader(const TimeRecord &total) override {
-    // Figure out how many spaces to description name.
-    unsigned padding = (80 - kTimingDescription.size()) / 2;
-    os << "===" << std::string(73, '-') << "===\n";
-    os.indent(padding) << kTimingDescription << '\n';
-    os << "===" << std::string(73, '-') << "===\n";
-
-    // Print the total time followed by the section headers.
-    os << llvm::format("  Total Execution Time: %.4f seconds\n\n", total.wall);
-    if (total.user != total.wall)
-      os << "  ----User Time----";
-    os << "  ----Wall Time----  ----Name----\n";
-  }
-
-  void printFooter() override { os.flush(); }
-
-  void printTime(const TimeRecord &time, const TimeRecord &total) override {
-    if (total.user != total.wall) {
-      os << llvm::format("  %8.4f (%5.1f%%)", time.user,
-                         100.0 * time.user / total.user);
-    }
-    os << llvm::format("  %8.4f (%5.1f%%)  ", time.wall,
-                       100.0 * time.wall / total.wall);
-  }
-
-  void printListEntry(StringRef name, const TimeRecord &time,
-                      const TimeRecord &total, bool lastEntry) override {
-    printTime(time, total);
-    os << name << "\n";
-  }
-
-  void printTreeEntry(unsigned indent, StringRef name, const TimeRecord &time,
-                      const TimeRecord &total) override {
-    printTime(time, total);
-    os.indent(indent) << name << "\n";
-  }
-
-  void printTreeEntryEnd(unsigned indent, bool lastEntry) override {}
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Support/Timing.cpp
+++ b/mlir/lib/Support/Timing.cpp
@@ -34,6 +34,9 @@ using namespace detail;
 using DisplayMode = DefaultTimingManager::DisplayMode;
 using OutputFormat = DefaultTimingManager::OutputFormat;
 
+constexpr llvm::StringLiteral kTimingDescription =
+    "... Execution time report ...";
+
 //===----------------------------------------------------------------------===//
 // TimingManager
 //===----------------------------------------------------------------------===//
@@ -106,6 +109,50 @@ TimingIdentifier TimingIdentifier::get(StringRef str, TimingManager &tm) {
 //===----------------------------------------------------------------------===//
 
 namespace {
+
+class OutputTextStrategy : public OutputStrategy {
+public:
+  OutputTextStrategy(raw_ostream &os) : OutputStrategy(os) {}
+
+  void printHeader(const TimeRecord &total) override {
+    // Figure out how many spaces to description name.
+    unsigned padding = (80 - kTimingDescription.size()) / 2;
+    os << "===" << std::string(73, '-') << "===\n";
+    os.indent(padding) << kTimingDescription << '\n';
+    os << "===" << std::string(73, '-') << "===\n";
+
+    // Print the total time followed by the section headers.
+    os << llvm::format("  Total Execution Time: %.4f seconds\n\n", total.wall);
+    if (total.user != total.wall)
+      os << "  ----User Time----";
+    os << "  ----Wall Time----  ----Name----\n";
+  }
+
+  void printFooter() override { os.flush(); }
+
+  void printTime(const TimeRecord &time, const TimeRecord &total) override {
+    if (total.user != total.wall) {
+      os << llvm::format("  %8.4f (%5.1f%%)", time.user,
+                         100.0 * time.user / total.user);
+    }
+    os << llvm::format("  %8.4f (%5.1f%%)  ", time.wall,
+                       100.0 * time.wall / total.wall);
+  }
+
+  void printListEntry(StringRef name, const TimeRecord &time,
+                      const TimeRecord &total, bool lastEntry) override {
+    printTime(time, total);
+    os << name << "\n";
+  }
+
+  void printTreeEntry(unsigned indent, StringRef name, const TimeRecord &time,
+                      const TimeRecord &total) override {
+    printTime(time, total);
+    os.indent(indent) << name << "\n";
+  }
+
+  void printTreeEntryEnd(unsigned indent, bool lastEntry) override {}
+};
 
 class OutputJsonStrategy : public OutputStrategy {
 public:


### PR DESCRIPTION
This reverts commit 7ce262291007d7f6961cefa7c41a809abd5bf30a.

## Summary
> Please add a short but exhaustive summary why you think your pull request is useful

## JIRA ticket

* E-163565

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* PR-17799(https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/17799)

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
