### PR TITLE
Fix thread handle leak on Windows

### DIFF
--- a/llvm/lib/Support/Windows/Threading.inc
+++ b/llvm/lib/Support/Windows/Threading.inc
@@ -41,6 +41,9 @@ void llvm_thread_join_impl(HANDLE hThread) {
   if (::WaitForSingleObject(hThread, INFINITE) == WAIT_FAILED) {
     ReportLastErrorFatal("WaitForSingleObject failed");
   }
+  if (::CloseHandle(hThread) == FALSE) {
+    ReportLastErrorFatal("CloseHandle failed");
+  }
 }
 
 void llvm_thread_detach_impl(HANDLE hThread) {


### PR DESCRIPTION
## Summary
Fix thread handle leak on Windows.

Unix implementation of llvm_thread_join_impl is simply calling pthread_join as no further cleanup is required with pthreads.
Windows implementation is calling WaitForSingleObject but handle closure is missing.

## JIRA ticket

* E-169967

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* PR-18345

### Other related tickets
