### PR TITLE
Revert "EISW-176770 Fix argument parsing issue in mlir-src-sharder after command-line parser reset"

### DIFF
--- a/mlir/tools/mlir-src-sharder/mlir-src-sharder.cpp
+++ b/mlir/tools/mlir-src-sharder/mlir-src-sharder.cpp
@@ -72,12 +72,6 @@ int main(int argc, char **argv) {
           "Name of the macro to be defined -- ignored by mlir-src-sharder"),
       llvm::cl::value_desc("macro name"), llvm::cl::Prefix);
 
-  // CMake/TableGen pass this flag, re-registering after ResetCommandLineParser
-  // avoids "unknown argument" errors.
-  llvm::cl::opt<bool> noWarnOnUnusedTemplateArg(
-      "no-warn-on-unused-template-args",
-      llvm::cl::desc("Disable unused template argument warnings."));
-
   llvm::InitLLVM y(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv);
 


### PR DESCRIPTION
## Summary
> Please add a short but exhaustive summary why you think your pull request is useful

The fix does not seem to do anything (at least on Linux).
This reverts commit https://github.com/intel/npu-plugin-llvm/commit/e764f8652eff0b0859c0abb28af573e62abbcc4e.

## JIRA ticket

* E-176770

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/22109

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
