### PR TITLE
Revert "[MLIR] Extend MlirOptMain API to register HW-specific options inside"

### DIFF
--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -294,11 +294,6 @@ protected:
   std::string generateReproducerFileFlag = "";
 };
 
-/// VPUX-specific method to get value for arch kind from command line
-/// and register HW-specific passes and pipelines
-using AdditionalRegistrationFn =
-      std::function<void(llvm::StringRef helpHeader)>;
-
 /// This defines the function type used to setup the pass manager. This can be
 /// used to pass in a callback to setup a default pass pipeline to be applied on
 /// the loaded IR.
@@ -326,12 +321,18 @@ LogicalResult MlirOptMain(llvm::raw_ostream &outputStream,
 /// Implementation for tools like `mlir-opt`.
 /// - toolName is used for the header displayed by `--help`.
 /// - registry should contain all the dialects that can be parsed in the source.
-/// - additionalRegistration will be called before the main command line parsing
-///   to perform additional registrations.
 LogicalResult MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
-                          DialectRegistry &registry,
-                          const AdditionalRegistrationFn &additionalRegistration
-                                  = [](llvm::StringRef){});
+                          DialectRegistry &registry);
+
+/// Implementation for tools like `mlir-opt`.
+/// This function can be used with registerAndParseCLIOptions so that
+/// CLI options can be accessed before running MlirOptMain.
+/// - inputFilename is the name of the input mlir file.
+/// - outputFilename is the name of the output file.
+/// - registry should contain all the dialects that can be parsed in the source.
+LogicalResult MlirOptMain(int argc, char **argv, llvm::StringRef inputFilename,
+                          llvm::StringRef outputFilename,
+                          DialectRegistry &registry);
 
 /// Helper wrapper to return the result of MlirOptMain directly from main.
 ///

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -630,41 +630,13 @@ LogicalResult mlir::MlirOptMain(llvm::raw_ostream &outputStream,
                                config.outputSplitMarker());
 }
 
-LogicalResult mlir::MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
-                                DialectRegistry &registry,
-                                const AdditionalRegistrationFn &additionalRegistration) {
-  static cl::opt<std::string> inputFilename(
-      cl::Positional, cl::desc("<input file>"), cl::init("-"));
-
-  static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
-                                             cl::value_desc("filename"),
-                                             cl::init("-"));
+LogicalResult mlir::MlirOptMain(int argc, char **argv,
+                                llvm::StringRef inputFilename,
+                                llvm::StringRef outputFilename,
+                                DialectRegistry &registry) {
 
   InitLLVM y(argc, argv);
 
-  // Register any command line options.
-  registerAsmPrinterCLOptions();
-  registerMLIRContextCLOptions();
-  registerPassManagerCLOptions();
-  registerDefaultTimingManagerCLOptions();
-  tracing::DebugCounter::registerCLOptions();
-
-  // Build the list of dialects as a header for the --help message.
-  std::string helpHeader = (toolName + "\nAvailable Dialects: ").str();
-  {
-    llvm::raw_string_ostream os(helpHeader);
-    interleaveComma(registry.getDialectNames(), os,
-                    [&](auto name) { os << name; });
-  }
-
-  // It is not possible to place a call after command line parser
-  // since not all options are registered at the moment
-  additionalRegistration(helpHeader);
-
-  MlirOptMainConfig::registerCLOptions(registry);
-
-  // Parse pass names in main to ensure static initialization completed.
-  cl::ParseCommandLineOptions(argc, argv, helpHeader);
   MlirOptMainConfig config = MlirOptMainConfig::createFromCLOptions();
 
   if (config.shouldShowDialects())
@@ -700,4 +672,15 @@ LogicalResult mlir::MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
   // Keep the output file if the invocation of MlirOptMain was successful.
   output->keep();
   return success();
+}
+
+LogicalResult mlir::MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
+                                DialectRegistry &registry) {
+
+  // Register and parse command line options.
+  std::string inputFilename, outputFilename;
+  std::tie(inputFilename, outputFilename) =
+      registerAndParseCLIOptions(argc, argv, toolName, registry);
+
+  return MlirOptMain(argc, argv, inputFilename, outputFilename, registry);
 }


### PR DESCRIPTION
## Summary

This reverts commit d0dd595c148cdb3e28917dad5146d9ce8ac75b84.

## JIRA ticket

* [EISW-141763](https://jira.devtools.intel.com/browse/EISW-141763)

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

* https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/22319 makes it possible to revert this patch

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
