### PR TITLE
[MLIR][ODS] Fully qualify namespace for mlir::Attribute in ODS generated code (cherry-pick from upstream)

### DIFF
--- a/mlir/include/mlir/IR/Properties.td
+++ b/mlir/include/mlir/IR/Properties.td
@@ -468,7 +468,7 @@ class ArrayProp<Property elem = Property<>, string newSummary = ""> :
       return $_diag() << "expected array attribute";
     for (::mlir::Attribute elemAttr : arrayAttr) {
       }] # _makePropStorage<elem, "elemVal">.ret # [{
-      auto elemRes = [&](Attribute propAttr, }] # elem.storageType # [{& propStorage) -> ::mlir::LogicalResult {
+      auto elemRes = [&](::mlir::Attribute propAttr, }] # elem.storageType # [{& propStorage) -> ::mlir::LogicalResult {
         }] # !subst("$_attr", "propAttr",
           !subst("$_storage", "propStorage", elem.convertFromAttribute)) # [{
       }(elemAttr, elemVal);
@@ -480,7 +480,7 @@ class ArrayProp<Property elem = Property<>, string newSummary = ""> :
   }];
 
   let convertToAttribute = [{
-    SmallVector<Attribute> elems;
+    SmallVector<::mlir::Attribute> elems;
     for (const auto& elemVal : $_storage) {
       auto elemAttr = [&](const }] # elem.storageType #[{& propStorage) -> ::mlir::Attribute {
         }] # !subst("$_storage", "propStorage", elem.convertToAttribute) # [{
@@ -647,7 +647,7 @@ class OptionalProp<Property p, bit canDelegateParsing = 1>
     }
     ::mlir::Attribute presentAttr = arrayAttr[0];
     }] # _makePropStorage<p, "presentVal">.ret # [{
-    auto presentRes = [&](Attribute propAttr, }] # p.storageType # [{& propStorage) -> ::mlir::LogicalResult {
+    auto presentRes = [&](::mlir::Attribute propAttr, }] # p.storageType # [{& propStorage) -> ::mlir::LogicalResult {
       }] # !subst("$_storage", "propStorage",
           !subst("$_attr", "propAttr", p.convertFromAttribute)) # [{
     }(presentAttr, presentVal);


### PR DESCRIPTION
## Summary
ODS generate code can be included and used outside of the `mlir`
namespace and so references to symbols in the mlir namespace
must be fully qualified.

## JIRA ticket

[EISW-190450](https://jira.devtools.intel.com/browse/EISW-190450)
[Core] Remove SmallVectorU8Prop and temporary optional property from core dialect

## Related PR in NPU Compiler and/or OpenVINO repository with sub-module update

(https://github.com/llvm/llvm-project/pull/168536)

### Other related tickets
> List tickets for additional work, eg, something was found during review but you agreed to address it in another Jira

* E-xxxxx
